### PR TITLE
srokeThickness corrected to strokeThickness

### DIFF
--- a/chapter2.md
+++ b/chapter2.md
@@ -293,7 +293,7 @@ First I tried this:
         stroke: 'rgba(0,0,0,0)'
         font: '30pt TheMinion',
         align: 'left',
-        srokeThickness: 4
+        strokeThickness: 4
       },
       hover: {
         fill: highlightColor,
@@ -371,7 +371,7 @@ var style;
       base: {
         font: '30pt TheMinion',
         align: 'left',
-        srokeThickness: 4
+        strokeThickness: 4
       },
       default: {
         fill: defaultColor,


### PR DESCRIPTION
lines  296 and 374 have 'srokeThickness' rather than 'strokeThickness'
